### PR TITLE
Load better quality background images

### DIFF
--- a/functions/get-background-image.js
+++ b/functions/get-background-image.js
@@ -22,6 +22,7 @@ exports.handler = async (event, context) => {
       statusCode: 200,
       body: JSON.stringify({
         photo_url: data.urls.regular,
+        photo_url_full: data.urls.full,
         photo_link: data.links.html,
         photo_blurhash: data.blur_hash,
         user_name: data.user.name,
@@ -39,6 +40,7 @@ exports.handler = async (event, context) => {
       statusCode: 200,
       body: JSON.stringify({
         photo_url: data.urls.regular,
+        photo_url_full: data.urls.full,
         photo_link: data.links.html,
         photo_blurhash: data.blur_hash,
         user_name: data.user.name,

--- a/src/components/SettingsFormBackgroundFields.svelte
+++ b/src/components/SettingsFormBackgroundFields.svelte
@@ -30,6 +30,7 @@ const handleRefresh = async () => {
   try {
     data.backgroundImage = await request;
     data.backgroundImageLastUpdate = Date.now();
+    delete data.backgroundPreloaded;
     currentRequest = null;
     handleChange();
   } catch (error) {
@@ -53,6 +54,7 @@ const handleBackgroundChange = async () => {
   } else {
     delete data.backgroundImage;
     delete data.backgroundImageLastUpdate;
+    delete data.backgroundPreloaded;
     data.backgroundRefreshFrequency = BACKGROUND_REFRESH_DAILY;
   }
   currentRequest = null;

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -91,7 +91,9 @@ export function initializeTheme() {
         await renderBackgroundImage(backgroundPreloaded ? backgroundImage.photo_url_full : backgroundImage.photo_url);
       }
 
-      if (backgroundImage.photo_url_full && !preview && !backgroundPreloaded) {
+      const shouldLoadBetterImage =
+        backgroundImage.photo_url_full && !preview && !backgroundPreloaded && !navigator.connection.saveData;
+      if (shouldLoadBetterImage) {
         await downloadBackgroundImage(backgroundImage.photo_url_full);
         settings.save({ ...settingsData, backgroundPreloaded: true });
       }

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -20,7 +20,7 @@ function createStore() {
   function preview(data) {
     update((settings) => {
       settingsCache = settingsCache || settings;
-      return data;
+      return { ...data, preview: true };
     });
   }
 


### PR DESCRIPTION
Resolves #3 

### Changes

- When background image is changed, after setting the regular image as background, preload the higher-quality image, relying on browser cache to speed up future loads
- Use [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API) to check data saver mode before downloading higher-quality image