### PR TITLE
Todos search and tag filters

### DIFF
--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -5,6 +5,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import { enableShortcut, disableShortcut } from '@features/shortcuts';
 import { tags } from '@features/tags/store';
 import { todos } from '@features/todos/store';
+import { search } from '@features/search/store';
 import { confirmation } from './stores/confirmation';
 
 import AppTopBar from './components/AppTopBar.svelte';
@@ -14,6 +15,8 @@ import AppTooltip from './components/AppTooltip.svelte';
 import AppConfirmation from './components/AppConfirmation.svelte';
 import TodoFormModal from '@features/todos/components/TodoFormModal.svelte';
 import TodoBoard from '@features/todos/components/TodoBoard.svelte';
+
+$: filteredTodos = search.filterTodos($todos);
 
 let todoFormData = {};
 let showTodoForm = false;
@@ -71,7 +74,7 @@ onDestroy(() => disableShortcut('addTodo'));
     />
     <TodoBoard
       class="TodoBoard"
-      todos={$todos}
+      todos={$filteredTodos}
       on:addtodo={showTodoFormWithData}
       on:updatetodo={updateTodoItem}
       on:edittodo={showTodoFormWithData}

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -22,6 +22,7 @@ body {
 
 a,
 input,
+select,
 textarea,
 button {
   font: inherit;

--- a/src/app/components/AppHeader.svelte
+++ b/src/app/components/AppHeader.svelte
@@ -3,7 +3,9 @@ import { createEventDispatcher } from 'svelte';
 import dayjs from 'dayjs';
 
 import { todos, removeDoneTimer } from '@features/todos/store';
+
 import Button from '@components/Button.svelte';
+import SearchForm from '@features/search/components/SearchForm.svelte';
 
 $: canUndoRemove = $removeDoneTimer > 0;
 $: hasDoneTodos = $todos.some((todo) => todo.done);
@@ -15,6 +17,8 @@ const today = dayjs().format('dddd, MMMM D');
 
 <header class={$$props.class}>
   <h1>{today}</h1>
+
+  <SearchForm />
 
   <div class="ButtonsWrapper">
     <Button primary on:click={() => dispatch('addtodo')}>Add Todo</Button>

--- a/src/app/components/AppHeader.svelte
+++ b/src/app/components/AppHeader.svelte
@@ -18,20 +18,22 @@ const today = dayjs().format('dddd, MMMM D');
 <header class={$$props.class}>
   <h1>{today}</h1>
 
-  <SearchForm />
+  <div class="HeaderActions">
+    <SearchForm />
 
-  <div class="ButtonsWrapper">
-    <Button primary on:click={() => dispatch('addtodo')}>Add Todo</Button>
-    {#if canUndoRemove}
-      <Button class="UndoRemoveButton" on:click={() => dispatch('undoremovedone')}>
-        <div class="Progress" style="--progress: {$removeDoneTimer * 100}%" />
-        <span>Undo Remove</span>
-      </Button>
-    {:else}
-      <Button class="RemoveDoneButton" text on:click={() => dispatch('removedone')} disabled={!hasDoneTodos}>
-        Remove Done
-      </Button>
-    {/if}
+    <div class="HeaderButtons">
+      <Button primary on:click={() => dispatch('addtodo')}>Add Todo</Button>
+      {#if canUndoRemove}
+        <Button class="UndoRemoveButton" on:click={() => dispatch('undoremovedone')}>
+          <div class="Progress" style="--progress: {$removeDoneTimer * 100}%" />
+          <span>Undo Remove</span>
+        </Button>
+      {:else}
+        <Button class="RemoveDoneButton" text on:click={() => dispatch('removedone')} disabled={!hasDoneTodos}>
+          Remove Done
+        </Button>
+      {/if}
+    </div>
   </div>
 </header>
 
@@ -70,14 +72,18 @@ header :global(.RemoveDoneButton) {
   min-width: 15.6rem;
 }
 
-.ButtonsWrapper {
+.HeaderActions,
+.HeaderButtons {
   display: flex;
   gap: 8px;
+}
+
+.HeaderButtons {
   padding: 8px;
   border-radius: 8px;
 }
 
-:global(body[data-background]) .ButtonsWrapper {
+:global(body[data-background]) .HeaderButtons {
   background-color: var(--main-transparent);
 }
 

--- a/src/assets/icons/close-dark.svg
+++ b/src/assets/icons/close-dark.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#111827" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+</svg>

--- a/src/assets/icons/close-light.svg
+++ b/src/assets/icons/close-light.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#ffffff" d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+</svg>

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -1,6 +1,7 @@
 <script>
 import orderBy from 'lodash/orderBy';
 
+import { settings } from '@features/settings/store';
 import { tags } from '@features/tags/store';
 import { search } from '../store';
 
@@ -8,31 +9,38 @@ import Button from '@components/Button.svelte';
 
 const { query, tag } = search;
 
-$: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
+$: enableSearchForm = $settings.enableTextFilter || $settings.enableTagsFilter;
 $: hasSearchFilters = Boolean($query) || Boolean($tag);
+$: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
 </script>
 
-<form class="SearchForm" on:submit|preventDefault>
-  <input class="SearchQuery" type="text" name="query" placeholder="Search todos" bind:value={$query} />
+{#if enableSearchForm}
+  <form class="SearchForm" on:submit|preventDefault>
+    {#if $settings.enableTextFilter}
+      <input class="SearchQuery" type="text" name="query" placeholder="Search todos" bind:value={$query} />
+    {/if}
 
-  <select class="SearchTags" name="tag" bind:value={$tag}>
-    <option value={null}>All todos</option>
-    {#each tagsChoices as tag}
-      <option value={tag.label}>{tag.label}</option>
-    {/each}
-  </select>
+    {#if $settings.enableTagsFilter}
+      <select class="SearchTags" name="tag" bind:value={$tag}>
+        <option value={null}>All todos</option>
+        {#each tagsChoices as tag}
+          <option value={tag.label}>{tag.label}</option>
+        {/each}
+      </select>
+    {/if}
 
-  <Button
-    icon
-    disabled={!hasSearchFilters}
-    data-tooltip="Clear search filters"
-    iconLight="./dist/assets/icons/close-light.svg"
-    iconDark="./dist/assets/icons/close-dark.svg"
-    on:click={search.clear}
-  >
-    Clear search
-  </Button>
-</form>
+    <Button
+      icon
+      disabled={!hasSearchFilters}
+      data-tooltip="Clear search filters"
+      iconLight="./dist/assets/icons/close-light.svg"
+      iconDark="./dist/assets/icons/close-dark.svg"
+      on:click={search.clear}
+    >
+      Clear search
+    </Button>
+  </form>
+{/if}
 
 <style>
 .SearchForm {

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -1,7 +1,9 @@
 <script>
+import { onMount, onDestroy } from 'svelte';
 import isEmpty from 'lodash/isEmpty';
 import orderBy from 'lodash/orderBy';
 
+import { enableShortcut, disableShortcut } from '@features/shortcuts';
 import { settings } from '@features/settings/store';
 import { tags } from '@features/tags/store';
 import { search } from '../store';
@@ -22,10 +24,20 @@ const handleKeyDown = (event) => {
     search.clear();
   }
 };
+
+let searchForm;
+const focusSearchForm = () => {
+  if (searchForm) {
+    searchForm.firstElementChild.focus();
+  }
+};
+
+onMount(() => enableShortcut('focusSearch', () => focusSearchForm()));
+onDestroy(() => disableShortcut('focusSearch'));
 </script>
 
 {#if enableSearchForm}
-  <form class="SearchForm" on:submit|preventDefault on:keydown={handleKeyDown}>
+  <form class="SearchForm" bind:this={searchForm} on:submit|preventDefault on:keydown={handleKeyDown}>
     {#if enableTextFilter}
       <input class="SearchQuery" type="text" name="query" placeholder="Search todos" bind:value={$query} />
     {/if}
@@ -45,6 +57,7 @@ const handleKeyDown = (event) => {
       data-tooltip="Clear search filters"
       iconLight="./dist/assets/icons/close-light.svg"
       iconDark="./dist/assets/icons/close-dark.svg"
+      type="button"
       class="SearchClear"
       on:click={search.clear}
     >

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -1,4 +1,5 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
 import orderBy from 'lodash/orderBy';
 
 import { settings } from '@features/settings/store';
@@ -9,18 +10,21 @@ import Button from '@components/Button.svelte';
 
 const { query, tag } = search;
 
-$: enableSearchForm = $settings.enableTextFilter || $settings.enableTagsFilter;
+$: enableTextFilter = $settings.enableTextFilter;
+$: enableTagsFilter = $settings.enableTagsFilter && !isEmpty($tags);
+$: enableSearchForm = enableTextFilter || enableTagsFilter;
+
 $: hasSearchFilters = Boolean($query) || Boolean($tag);
 $: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
 </script>
 
 {#if enableSearchForm}
   <form class="SearchForm" on:submit|preventDefault>
-    {#if $settings.enableTextFilter}
+    {#if enableTextFilter}
       <input class="SearchQuery" type="text" name="query" placeholder="Search todos" bind:value={$query} />
     {/if}
 
-    {#if $settings.enableTagsFilter}
+    {#if enableTagsFilter}
       <select class="SearchTags" name="tag" bind:value={$tag}>
         <option value={null}>All todos</option>
         {#each tagsChoices as tag}

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -4,6 +4,29 @@ import { search } from '../store';
 const query = search.query;
 </script>
 
-<form on:submit|preventDefault>
-  <input type="text" bind:value={$query} />
+<form class="SearchForm" on:submit|preventDefault>
+  <input class="SearchQuery" type="text" placeholder="Search todos" bind:value={$query} />
 </form>
+
+<style>
+.SearchForm {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 8px;
+}
+
+:global(body[data-background]) .SearchForm {
+  background-color: var(--main-transparent);
+}
+
+.SearchQuery {
+  display: block;
+  width: 20rem;
+  padding: 8px 1.2rem;
+  border: 2px solid var(--dimmed-300);
+  border-radius: 8px;
+  line-height: 2.4rem;
+  background-color: transparent;
+}
+</style>

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -1,0 +1,9 @@
+<script>
+import { search } from '../store';
+
+const query = search.query;
+</script>
+
+<form on:submit|preventDefault>
+  <input type="text" bind:value={$query} />
+</form>

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -2,7 +2,10 @@
 import { tags } from '@features/tags/store';
 import { search } from '../store';
 
+import Button from '@components/Button.svelte';
+
 const { query, tag } = search;
+$: hasSearchFilters = Boolean($query) || Boolean($tag);
 </script>
 
 <form class="SearchForm" on:submit|preventDefault>
@@ -14,6 +17,17 @@ const { query, tag } = search;
       <option value={tag.label}>{tag.label}</option>
     {/each}
   </select>
+
+  <Button
+    icon
+    disabled={!hasSearchFilters}
+    data-tooltip="Clear search filters"
+    iconLight="./dist/assets/icons/close-light.svg"
+    iconDark="./dist/assets/icons/close-dark.svg"
+    on:click={search.clear}
+  >
+    Clear search
+  </Button>
 </form>
 
 <style>

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -1,10 +1,14 @@
 <script>
+import orderBy from 'lodash/orderBy';
+
 import { tags } from '@features/tags/store';
 import { search } from '../store';
 
 import Button from '@components/Button.svelte';
 
 const { query, tag } = search;
+
+$: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
 $: hasSearchFilters = Boolean($query) || Boolean($tag);
 </script>
 
@@ -13,7 +17,7 @@ $: hasSearchFilters = Boolean($query) || Boolean($tag);
 
   <select class="SearchTags" name="tag" bind:value={$tag}>
     <option value={null}>All todos</option>
-    {#each Object.values($tags) as tag}
+    {#each tagsChoices as tag}
       <option value={tag.label}>{tag.label}</option>
     {/each}
   </select>

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -35,6 +35,7 @@ $: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
       data-tooltip="Clear search filters"
       iconLight="./dist/assets/icons/close-light.svg"
       iconDark="./dist/assets/icons/close-dark.svg"
+      class="SearchClear"
       on:click={search.clear}
     >
       Clear search
@@ -55,13 +56,18 @@ $: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
 }
 
 .SearchQuery,
+.SearchTags,
+.SearchForm :global(button.icon.SearchClear) {
+  background-color: var(--main);
+}
+
+.SearchQuery,
 .SearchTags {
   display: block;
   padding: 8px 1.2rem;
   border: 2px solid var(--dimmed-300);
   border-radius: 8px;
   line-height: 2.4rem;
-  background-color: transparent;
 }
 
 .SearchQuery {

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -16,10 +16,16 @@ $: enableSearchForm = enableTextFilter || enableTagsFilter;
 
 $: hasSearchFilters = Boolean($query) || Boolean($tag);
 $: tagsChoices = orderBy($tags, (tag) => tag.label.toUpperCase());
+
+const handleKeyDown = (event) => {
+  if (event.key === 'Escape') {
+    search.clear();
+  }
+};
 </script>
 
 {#if enableSearchForm}
-  <form class="SearchForm" on:submit|preventDefault>
+  <form class="SearchForm" on:submit|preventDefault on:keydown={handleKeyDown}>
     {#if enableTextFilter}
       <input class="SearchQuery" type="text" name="query" placeholder="Search todos" bind:value={$query} />
     {/if}

--- a/src/features/search/components/SearchForm.svelte
+++ b/src/features/search/components/SearchForm.svelte
@@ -1,11 +1,19 @@
 <script>
+import { tags } from '@features/tags/store';
 import { search } from '../store';
 
-const query = search.query;
+const { query, tag } = search;
 </script>
 
 <form class="SearchForm" on:submit|preventDefault>
-  <input class="SearchQuery" type="text" placeholder="Search todos" bind:value={$query} />
+  <input class="SearchQuery" type="text" name="query" placeholder="Search todos" bind:value={$query} />
+
+  <select class="SearchTags" name="tag" bind:value={$tag}>
+    <option value={null}>All todos</option>
+    {#each Object.values($tags) as tag}
+      <option value={tag.label}>{tag.label}</option>
+    {/each}
+  </select>
 </form>
 
 <style>
@@ -20,13 +28,21 @@ const query = search.query;
   background-color: var(--main-transparent);
 }
 
-.SearchQuery {
+.SearchQuery,
+.SearchTags {
   display: block;
-  width: 20rem;
   padding: 8px 1.2rem;
   border: 2px solid var(--dimmed-300);
   border-radius: 8px;
   line-height: 2.4rem;
   background-color: transparent;
+}
+
+.SearchQuery {
+  width: 24rem;
+}
+
+.SearchTags {
+  max-width: 15rem;
 }
 </style>

--- a/src/features/search/settings/SearchSettings.svelte
+++ b/src/features/search/settings/SearchSettings.svelte
@@ -1,0 +1,61 @@
+<script>
+import { getDefaultSettings } from '.';
+import Switch from '@components/Switch.svelte';
+
+export let data = getDefaultSettings();
+</script>
+
+<section>
+  <div class="Field--inline">
+    <label for="enableTextFilter">
+      Enable text filter
+      <small>Show todos that match the search query</small>
+    </label>
+    <Switch name="enableTextFilter" bind:value={data.enableTextFilter} on:change />
+  </div>
+
+  <div class="Field--inline">
+    <label for="enableTagsFilter">
+      Enable tags filter
+      <small>Show todos containing the selected tag</small>
+    </label>
+    <Switch name="enableTagsFilter" bind:value={data.enableTagsFilter} on:change />
+  </div>
+</section>
+
+<style>
+section {
+  display: flex;
+  flex-direction: column;
+  gap: 3.6rem;
+}
+
+.Field--inline {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 1.7rem;
+  font-weight: 600;
+}
+
+.Field--inline label {
+  margin-right: auto;
+  margin-bottom: 0;
+}
+
+.Field--inline label + :global(*) {
+  margin-top: 1px;
+}
+
+small {
+  display: block;
+  font-size: 1.3rem;
+  font-weight: 400;
+  color: var(--dimmed-500);
+}
+</style>

--- a/src/features/search/settings/SearchSettings.svelte
+++ b/src/features/search/settings/SearchSettings.svelte
@@ -9,7 +9,7 @@ export let data = getDefaultSettings();
   <div class="Field--inline">
     <label for="enableTextFilter">
       Enable text filter
-      <small>Show todos that match the search query</small>
+      <small>Show todos that match the search query.</small>
     </label>
     <Switch name="enableTextFilter" bind:value={data.enableTextFilter} on:change />
   </div>
@@ -17,7 +17,7 @@ export let data = getDefaultSettings();
   <div class="Field--inline">
     <label for="enableTagsFilter">
       Enable tags filter
-      <small>Show todos containing the selected tag</small>
+      <small>Show todos containing the selected tag. Remains hidden if there are no tags available.</small>
     </label>
     <Switch name="enableTagsFilter" bind:value={data.enableTagsFilter} on:change />
   </div>
@@ -49,6 +49,7 @@ label {
 }
 
 .Field--inline label + :global(*) {
+  flex-shrink: 0;
   margin-top: 1px;
 }
 

--- a/src/features/search/settings/index.js
+++ b/src/features/search/settings/index.js
@@ -1,0 +1,11 @@
+import SearchSettings from './SearchSettings.svelte';
+
+export const id = 'SEARCH';
+export const label = 'Search';
+export const component = SearchSettings;
+
+export const getDefaultSettings = () => ({
+  enableTextFilter: true,
+  enableTagsFilter: false,
+});
+export const allowedFields = ['enableTextFilter', 'enableTagsFilter'];

--- a/src/features/search/settings/index.js
+++ b/src/features/search/settings/index.js
@@ -1,3 +1,4 @@
+import { search } from '../store';
 import SearchSettings from './SearchSettings.svelte';
 
 export const id = 'SEARCH';
@@ -9,3 +10,11 @@ export const getDefaultSettings = () => ({
   enableTagsFilter: true,
 });
 export const allowedFields = ['enableTextFilter', 'enableTagsFilter'];
+
+export const onSave = (settings, updated) => {
+  const textFilterChanged = settings.enableTextFilter !== updated.enableTextFilter;
+  const tagsFilterChanged = settings.enableTagsFilter !== updated.enableTagsFilter;
+  if (textFilterChanged || tagsFilterChanged) {
+    search.clear();
+  }
+};

--- a/src/features/search/settings/index.js
+++ b/src/features/search/settings/index.js
@@ -6,6 +6,6 @@ export const component = SearchSettings;
 
 export const getDefaultSettings = () => ({
   enableTextFilter: true,
-  enableTagsFilter: false,
+  enableTagsFilter: true,
 });
 export const allowedFields = ['enableTextFilter', 'enableTagsFilter'];

--- a/src/features/search/store.js
+++ b/src/features/search/store.js
@@ -4,6 +4,11 @@ function createStore() {
   const query = writable('');
   const tag = writable(null);
 
+  function clear() {
+    query.set('');
+    tag.set(null);
+  }
+
   function filterTodos(todos) {
     const results = writable(todos);
     const matchesAny = (string, patterns) => patterns.some((pattern) => pattern.test(string));
@@ -39,7 +44,7 @@ function createStore() {
     return results;
   }
 
-  return { query, tag, filterTodos };
+  return { query, tag, clear, filterTodos };
 }
 
 export const search = createStore();

--- a/src/features/search/store.js
+++ b/src/features/search/store.js
@@ -2,24 +2,44 @@ import { writable } from 'svelte/store';
 
 function createStore() {
   const query = writable('');
+  const tag = writable(null);
 
   function filterTodos(todos) {
     const results = writable(todos);
     const matchesAny = (string, patterns) => patterns.some((pattern) => pattern.test(string));
 
-    query.subscribe((query) => {
-      const patterns = query
+    let queryValue = '';
+    let tagValue = null;
+
+    const filterResults = () => {
+      const patterns = queryValue
         .trim()
         .split(/\s+/g)
         .map((word) => new RegExp(word, 'gi'));
 
-      const matches = query.trim().length === 0 ? todos : todos.filter((todo) => matchesAny(todo.body, patterns));
-      results.set(matches);
+      let filtered = todos;
+      if (tagValue) {
+        filtered = filtered.filter((todo) => todo.tags.includes(tagValue));
+      }
+      if (queryValue) {
+        filtered = filtered.filter((todo) => matchesAny(todo.body, patterns));
+      }
+      results.set(filtered);
+    };
+
+    query.subscribe((query) => {
+      queryValue = query;
+      filterResults();
     });
+    tag.subscribe((tag) => {
+      tagValue = tag;
+      filterResults();
+    });
+
     return results;
   }
 
-  return { query, filterTodos };
+  return { query, tag, filterTodos };
 }
 
 export const search = createStore();

--- a/src/features/search/store.js
+++ b/src/features/search/store.js
@@ -1,0 +1,25 @@
+import { writable } from 'svelte/store';
+
+function createStore() {
+  const query = writable('');
+
+  function filterTodos(todos) {
+    const results = writable(todos);
+    const matchesAny = (string, patterns) => patterns.some((pattern) => pattern.test(string));
+
+    query.subscribe((query) => {
+      const patterns = query
+        .trim()
+        .split(/\s+/g)
+        .map((word) => new RegExp(word, 'gi'));
+
+      const matches = query.trim().length === 0 ? todos : todos.filter((todo) => matchesAny(todo.body, patterns));
+      results.set(matches);
+    });
+    return results;
+  }
+
+  return { query, filterTodos };
+}
+
+export const search = createStore();

--- a/src/features/settings/config.js
+++ b/src/features/settings/config.js
@@ -2,6 +2,7 @@ import * as ThemeSettings from '@features/themes/settings';
 import * as BackgroundSettings from '@features/backgrounds/settings';
 import * as QuickLinksSettings from '@features/quick-links/settings';
 import * as TagsSettings from '@features/tags/settings';
+import * as SearchSettings from '@features/search/settings';
 import * as ShortcutsSettings from '@features/shortcuts/settings';
 import * as MiscellaneousSettings from '@features/settings/settings';
 
@@ -10,6 +11,7 @@ export const settingsTabs = [
   BackgroundSettings,
   QuickLinksSettings,
   TagsSettings,
+  SearchSettings,
   ShortcutsSettings,
   MiscellaneousSettings,
 ];

--- a/src/features/settings/settings/MiscellaneousSettings.svelte
+++ b/src/features/settings/settings/MiscellaneousSettings.svelte
@@ -9,7 +9,7 @@ export let data = getDefaultSettings();
   <div class="Field--inline">
     <label for="enablePrivacyMode">
       Enable privacy mode
-      <small>Quickly toggle by pressing <kbd>Alt+P</kbd></small>
+      <small>Blur out todo contents. Toggle by pressing <kbd>Alt+P</kbd></small>
     </label>
     <Switch name="enablePrivacyMode" bind:value={data.enablePrivacyMode} on:change />
   </div>

--- a/src/features/settings/settings/MiscellaneousSettings.svelte
+++ b/src/features/settings/settings/MiscellaneousSettings.svelte
@@ -9,7 +9,7 @@ export let data = getDefaultSettings();
   <div class="Field--inline">
     <label for="enablePrivacyMode">
       Enable privacy mode
-      <small>Blur out todo contents. Toggle by pressing <kbd>Alt+P</kbd></small>
+      <small>Blur out todo contents. Toggle by pressing <kbd>Alt+P</kbd>.</small>
     </label>
     <Switch name="enablePrivacyMode" bind:value={data.enablePrivacyMode} on:change />
   </div>
@@ -41,6 +41,7 @@ label {
 }
 
 .Field--inline label + :global(*) {
+  flex-shrink: 0;
   margin-top: 1px;
 }
 

--- a/src/features/shortcuts/settings/ShortcutsSettings.svelte
+++ b/src/features/shortcuts/settings/ShortcutsSettings.svelte
@@ -16,6 +16,7 @@ const getItemKeys = (item) => {
     altKey: 'Alt',
     metaKey: 'Cmd',
     ctrlKey: 'Ctrl',
+    Slash: '/',
   };
   return keys.map((key) =>
     key

--- a/src/features/shortcuts/shortcuts.json
+++ b/src/features/shortcuts/shortcuts.json
@@ -13,5 +13,12 @@
   "togglePrivacyMode": {
     "label": "Toggle privacy mode",
     "keys": ["altKey", "KeyP"]
+  },
+  "focusSearch": {
+    "label": "Focus search",
+    "keys": [
+      ["ctrlKey", "Slash"],
+      ["metaKey", "Slash"]
+    ]
   }
 }


### PR DESCRIPTION
Resolves #47 , will be released in [`v1.13.0`](https://github.com/arnellebalane/simple-todo/milestone/8)

### Changes

- Add search form with text search and tags dropdown for filtering todos
- Add search settings tab
- Add new shortcut to focus search form

![image](https://user-images.githubusercontent.com/1428598/151958688-12c36f53-870d-4a50-931a-f9b7cd74bc2d.png)

![image](https://user-images.githubusercontent.com/1428598/151958738-4e1009d1-b2df-4a6a-9760-d19c3f9d59dc.png)
