### PR TITLE
Prevent tooltips from overflowing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "simple-todo",
       "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/dom": "^0.2.0",
         "@sentry/browser": "^6.3.6",
         "@sentry/integrations": "^6.3.6",
         "@sentry/node": "^6.3.6",
@@ -31,6 +33,19 @@
         "prettier": "^2.2.1",
         "prettier-plugin-svelte": "^2.2.0",
         "snowpack": "^3.3.7"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-99Pnb5T2S7PSE8rKHD5fZWWnXE3a2xG9E8eQm8SIMYWJyJoHDJIt0b9SK3UjetWFcepxVG+ZMDxcfbamyx+HSg=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.2.0.tgz",
+      "integrity": "sha512-hNhTbImiJ8SH9rHsP0qcE9IVxn/maMhwWA5d17p7EkEzVdciayB664Qy2Vxa8RxY/8avE8iVKkfE8sIeg34J0g==",
+      "dependencies": {
+        "@floating-ui/core": "^0.4.0"
       }
     },
     "node_modules/@lhci/cli": {
@@ -30690,6 +30705,19 @@
     }
   },
   "dependencies": {
+    "@floating-ui/core": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-99Pnb5T2S7PSE8rKHD5fZWWnXE3a2xG9E8eQm8SIMYWJyJoHDJIt0b9SK3UjetWFcepxVG+ZMDxcfbamyx+HSg=="
+    },
+    "@floating-ui/dom": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.2.0.tgz",
+      "integrity": "sha512-hNhTbImiJ8SH9rHsP0qcE9IVxn/maMhwWA5d17p7EkEzVdciayB664Qy2Vxa8RxY/8avE8iVKkfE8sIeg34J0g==",
+      "requires": {
+        "@floating-ui/core": "^0.4.0"
+      }
+    },
     "@lhci/cli": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Arnelle Balane <arnellebalane@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "@floating-ui/dom": "^0.2.0",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@sentry/node": "^6.3.6",


### PR DESCRIPTION
Resolves #60 , will be released in [`v1.13.0`](https://github.com/arnellebalane/simple-todo/milestone/8)

### Changes

- Use [`floating-ui`](https://floating-ui.com/) to keep tooltips inside the viewport

![image](https://user-images.githubusercontent.com/1428598/152000208-b294af4b-b56a-43c5-abe2-071918e7b127.png)
