### PR TITLE
Add unit tests for settings feature components

### DIFF
--- a/src/app/components/AppTopBar.spec.js
+++ b/src/app/components/AppTopBar.spec.js
@@ -89,6 +89,6 @@ describe('AppTopBar', () => {
         cy.mount(AppTopBar);
 
         cy.get('[data-cy="settings-btn"]').click();
-        cy.get('[data-cy="settings-modal"]').should('be.visible');
+        cy.get('[data-cy="settings-form-modal"]').should('be.visible');
     });
 });

--- a/src/features/settings/components/SettingsForm.spec.js
+++ b/src/features/settings/components/SettingsForm.spec.js
@@ -1,0 +1,77 @@
+import { COLOR_GREEN, COLOR_YELLOW, THEME_LIGHT, THEME_SYSTEM } from '@features/themes/constants';
+import SettingsForm from './SettingsForm.svelte';
+
+describe('SettingsForm', () => {
+    beforeEach(() => {
+        cy.viewport(800, 800);
+    });
+
+    it('dispatches "submit" event when save changes button is clicked', () => {
+        const submitSpy = cy.spy();
+        const data = {
+            theme: THEME_SYSTEM,
+            color: COLOR_GREEN,
+        };
+
+        cy.mount(SettingsForm, {
+            props: {
+                data,
+            },
+        }).then(({ component }) => {
+            component.$on('submit', submitSpy);
+        });
+
+        cy.get('[data-cy="settings-form-submit"]').click();
+        cy.wrap(submitSpy).should('have.been.calledWith', Cypress.sinon.match({ detail: data }));
+    });
+
+    it('dispatches "cancel" event when cancel button is clicked', () => {
+        const cancelSpy = cy.spy();
+
+        cy.mount(SettingsForm).then(({ component }) => {
+            component.$on('cancel', cancelSpy);
+        });
+
+        cy.get('[data-cy="settings-form-cancel"]').click();
+        cy.wrap(cancelSpy).should('have.been.called');
+    });
+
+    it('dispatches "change" event when setings tab content fields has changes', () => {
+        const changeSpy = cy.spy();
+        const data = {
+            theme: THEME_SYSTEM,
+            color: COLOR_GREEN,
+        };
+
+        cy.mount(SettingsForm, {
+            props: {
+                data,
+            },
+        }).then(({ component }) => {
+            component.$on('change', changeSpy);
+        });
+
+        cy.get(`[data-cy="theme-settings-selector"] input[value="${THEME_LIGHT}"]`).click({ force: true });
+        cy.get(`[data-cy="color-settings-selector"] input[value="${COLOR_YELLOW}"]`).click({ force: true });
+
+        cy.wrap(changeSpy).should(
+            'have.been.calledWith',
+            Cypress.sinon.match({
+                detail: {
+                    theme: THEME_LIGHT,
+                    color: COLOR_YELLOW,
+                },
+            }),
+        );
+    });
+
+    it('displays settings form content corresponding to selected settings tab', () => {
+        cy.mount(SettingsForm);
+
+        cy.contains('Theme').click();
+        cy.get('[data-cy="theme-settings-selector"]').should('exist');
+
+        cy.contains('Background').click();
+        cy.get('[data-cy="toggle-background"]').should('exist');
+    });
+});

--- a/src/features/settings/components/SettingsForm.svelte
+++ b/src/features/settings/components/SettingsForm.svelte
@@ -25,8 +25,8 @@ const handleChange = () => dispatch('change', data);
     </div>
 
     <div class="Actions">
-        <Button primary>Save Settings</Button>
-        <Button type="button" text on:click={() => dispatch('cancel')}>Cancel</Button>
+        <Button primary data-cy="settings-form-submit">Save Settings</Button>
+        <Button type="button" text on:click={() => dispatch('cancel')} data-cy="settings-form-cancel">Cancel</Button>
     </div>
 </form>
 

--- a/src/features/settings/components/SettingsFormModal.spec.js
+++ b/src/features/settings/components/SettingsFormModal.spec.js
@@ -1,0 +1,19 @@
+import SettingsFormModal from './SettingsFormModal.svelte';
+
+describe('SettingsFormModal', () => {
+    it('hides the modal when show prop is false', () => {
+        cy.mount(SettingsFormModal);
+
+        cy.get('[data-cy="settings-form-modal"]').should('not.exist');
+    });
+
+    it('displays the modal when show prop is true', () => {
+        cy.mount(SettingsFormModal, {
+            props: {
+                show: true,
+            },
+        });
+
+        cy.get('[data-cy="settings-form-modal"]').should('be.visible');
+    });
+});

--- a/src/features/settings/components/SettingsFormModal.svelte
+++ b/src/features/settings/components/SettingsFormModal.svelte
@@ -16,7 +16,7 @@ const dispatch = createEventDispatcher();
     closeOnEscape
     closeOnClickOutside
     on:close
-    data-cy="settings-modal"
+    data-cy="settings-form-modal"
 >
     <SettingsForm {data} on:change on:submit on:cancel={() => dispatch('close')} />
 </Modal>

--- a/src/features/settings/components/SettingsFormSidebar.spec.js
+++ b/src/features/settings/components/SettingsFormSidebar.spec.js
@@ -1,0 +1,16 @@
+import SettingsFormSidebar from './SettingsFormSidebar.svelte';
+import { settingsTabs } from '../config';
+
+describe('SettingsFormSidebar', () => {
+    beforeEach(() => {
+        cy.viewport(300, 500);
+    });
+
+    it('renders all supported settings tabs', () => {
+        cy.mount(SettingsFormSidebar);
+
+        for (const { label } of settingsTabs) {
+            cy.contains(label);
+        }
+    });
+});

--- a/src/features/settings/settings/MiscellaneousSettings.spec.js
+++ b/src/features/settings/settings/MiscellaneousSettings.spec.js
@@ -1,0 +1,35 @@
+import { component as MiscellaneousSettings } from '.';
+
+describe('MiscellaneousSettings', () => {
+    beforeEach(() => {
+        cy.viewport(500, 500);
+    });
+
+    it('toggles privacy mode switch based on enablePrivacyMode prop value', () => {
+        cy.mount(MiscellaneousSettings, {
+            props: {
+                data: {
+                    enablePrivacyMode: true,
+                },
+            },
+        });
+
+        cy.get('[data-cy="enable-privacy-mode-toggle"]').should('be.checked');
+    });
+
+    it('dispatches "change" event when privacy mode switch is toggled', () => {
+        const changeSpy = cy.spy();
+        const data = {
+            enablePrivacyMode: false,
+        };
+
+        cy.mount(MiscellaneousSettings, {
+            props: { data },
+        }).then(({ component }) => {
+            component.$on('change', changeSpy);
+        });
+
+        cy.get('[data-cy="enable-privacy-mode-toggle"]').click({ force: true });
+        cy.wrap(changeSpy).should('have.been.called');
+    });
+});

--- a/src/features/settings/settings/MiscellaneousSettings.svelte
+++ b/src/features/settings/settings/MiscellaneousSettings.svelte
@@ -11,7 +11,12 @@ export let data = getDefaultSettings();
             Enable privacy mode
             <small>Blur out todo contents. Toggle by pressing <kbd>Alt+P</kbd>.</small>
         </label>
-        <Switch name="enablePrivacyMode" bind:value={data.enablePrivacyMode} on:change />
+        <Switch
+            name="enablePrivacyMode"
+            bind:value={data.enablePrivacyMode}
+            on:change
+            data-cy="enable-privacy-mode-toggle"
+        />
     </div>
 </section>
 

--- a/src/features/settings/store.spec.js
+++ b/src/features/settings/store.spec.js
@@ -1,0 +1,85 @@
+import { THEME_SYSTEM } from '@features/themes/constants';
+import { STORAGE_KEY_SETTINGS } from '@lib/constants';
+import { settings } from './store';
+
+describe('settings store', () => {
+    beforeEach(() => {
+        settings.set({});
+    });
+
+    it('returns preview flag when settings.preview is called', () => {
+        const settingsSpy = cy.spy();
+        settings.subscribe(settingsSpy);
+
+        const data = {
+            theme: THEME_SYSTEM,
+        };
+        settings.preview(data);
+
+        cy.wrap(settingsSpy).should('have.been.calledWith', { ...data, preview: true });
+    });
+
+    it('restores original settings before preview when settings.restore is called', () => {
+        const data = {
+            theme: THEME_SYSTEM,
+        };
+        settings.preview(data);
+
+        const settingsSpy = cy.spy();
+        settings.subscribe(settingsSpy);
+
+        settings.restore();
+
+        cy.wrap(settingsSpy).should('have.been.calledWith', {});
+    });
+
+    it('picks only allowed fields when settings.save is called', () => {
+        const settingsSpy = cy.spy();
+        settings.subscribe(settingsSpy);
+
+        const data = {
+            theme: THEME_SYSTEM,
+            unknown: 'UNKNOWN_VALUE',
+        };
+        settings.save(data);
+
+        cy.wrap(settingsSpy).should('have.been.calledWith', {
+            theme: THEME_SYSTEM,
+        });
+    });
+
+    it('saves settings in localStorage when settings.saveInStorage is called', () => {
+        const data = {
+            theme: THEME_SYSTEM,
+        };
+        settings.saveInStorage(data);
+
+        cy.window().then((win) => {
+            cy.getAllLocalStorage().then((localStorage) => {
+                cy.log(win.location.origin);
+                cy.log(localStorage);
+
+                const storedSettings = localStorage[win.location.origin][STORAGE_KEY_SETTINGS];
+                const expectedSettings = JSON.stringify(data);
+
+                cy.wrap(storedSettings).should('equal', expectedSettings);
+            });
+        });
+    });
+
+    it('toggles privacy mode value when settings.togglePrivacyMode is called', () => {
+        const data = {
+            enablePrivacyMode: false,
+        };
+        settings.saveInStorage(data);
+
+        const settingsSpy = cy.spy();
+        settings.subscribe(settingsSpy);
+
+        settings.togglePrivacyMode();
+
+        cy.wrap(settingsSpy).should('have.been.calledWith', {
+            enablePrivacyMode: true,
+        });
+    });
+});

--- a/src/features/themes/settings/ThemeSettings.svelte
+++ b/src/features/themes/settings/ThemeSettings.svelte
@@ -40,6 +40,7 @@ const colorChoices = [
             choices={themeChoices}
             choiceComponent={ThemeChoiceField}
             on:change
+            data-cy="theme-settings-selector"
         />
     </div>
 
@@ -51,6 +52,7 @@ const colorChoices = [
             choices={colorChoices}
             choiceComponent={ColorChoiceField}
             on:change
+            data-cy="color-settings-selector"
         />
     </div>
 </section>


### PR DESCRIPTION
### Changes

- Add unit tests for the components and modules in `src/features/settings`, partially implementing for #95

### Running the tests

```bash
npm test -- --spec src/features/settings
```

```text
       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  store.spec.js                             82ms        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  components/SettingsForm.spec.js          591ms        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  components/SettingsFormModal.spec.j       60ms        2        2        -        -        - │
  │    s                                                                                           │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  components/SettingsFormSidebar.spec       87ms        1        1        -        -        - │
  │    .js                                                                                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  settings/MiscellaneousSettings.spec      134ms        2        2        -        -        - │
  │    .js                                                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        954ms       14       14        -        -        -
```