### PR TITLE
Add unit tests for shortcuts feature components

### DIFF
--- a/src/features/shortcuts/settings/ShortcutsSettings.spec.js
+++ b/src/features/shortcuts/settings/ShortcutsSettings.spec.js
@@ -1,0 +1,16 @@
+import { component as ShortcutsSettings } from '.';
+import shortcuts from '../shortcuts.json';
+
+describe('ShortcutsSettings', () => {
+    beforeEach(() => {
+        cy.viewport(500, 500);
+    });
+
+    it('renders all supported shortcuts', () => {
+        cy.mount(ShortcutsSettings);
+
+        for (const { label } of Object.values(shortcuts)) {
+            cy.contains(label);
+        }
+    });
+});


### PR DESCRIPTION
### Changes

- Add unit tests for the components and modules in `src/features/shortcuts`, partially implementing for #95

### Running the tests

```bash
npm test -- --spec src/features/shortcuts
```

```text
       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  ShortcutsSettings.spec.js                 80ms        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                         80ms        1        1        -        -        -
```