### PR TITLE
Add unit tests for tags feature components

### DIFF
--- a/src/features/settings/store.spec.js
+++ b/src/features/settings/store.spec.js
@@ -56,9 +56,6 @@ describe('settings store', () => {
 
         cy.window().then((win) => {
             cy.getAllLocalStorage().then((localStorage) => {
-                cy.log(win.location.origin);
-                cy.log(localStorage);
-
                 const storedSettings = localStorage[win.location.origin][STORAGE_KEY_SETTINGS];
                 const expectedSettings = JSON.stringify(data);
 

--- a/src/features/tags/components/TagsInput.spec.js
+++ b/src/features/tags/components/TagsInput.spec.js
@@ -1,0 +1,64 @@
+import TagsInput from './TagsInput.svelte';
+
+describe('TagsInput', () => {
+    beforeEach(() => {
+        cy.viewport(500, 500);
+    });
+
+    it('renders current list of values', () => {
+        const value = ['one', 'two'];
+
+        cy.mount(TagsInput, {
+            props: {
+                value,
+                choices: [],
+            },
+        });
+
+        for (const tag of value) {
+            cy.get('[data-cy="tags-value"]').contains(tag);
+        }
+    });
+
+    it('renders new value in list of values and resets input when enter key is pressed', () => {
+        cy.mount(TagsInput, {
+            props: {
+                value: [],
+                choices: [],
+            },
+        });
+
+        cy.get('[data-cy="tags-input"]').type('one');
+        cy.get('[data-cy="tags-input"]').focus().trigger('keydown', { code: 'Enter' });
+
+        cy.get('[data-cy="tags-value"]').contains('one');
+        cy.get('[data-cy="tags-input"]').should('have.value', '');
+    });
+
+    it('ignores new value when it is already in the list of values', () => {
+        cy.mount(TagsInput, {
+            props: {
+                value: ['one'],
+                choices: [],
+            },
+        });
+
+        cy.get('[data-cy="tags-input"]').type('one');
+        cy.get('[data-cy="tags-input"]').focus().trigger('keydown', { code: 'Enter' });
+
+        cy.get('[data-cy="tags-value"]').contains('one').should('have.length', 1);
+        cy.get('[data-cy="tags-input"]').should('have.value', '');
+    });
+
+    it('removes value from values when it is clicked', () => {
+        cy.mount(TagsInput, {
+            props: {
+                value: ['one'],
+                choices: [],
+            },
+        });
+
+        cy.get('[data-cy="tags-value"]').click();
+        cy.get('[data-cy="tags-value"]').should('have.length', 0);
+    });
+});

--- a/src/features/tags/components/TagsInput.svelte
+++ b/src/features/tags/components/TagsInput.svelte
@@ -30,11 +30,19 @@ const handleRemove = (tag) => {
     name={$$props.name}
     id={$$props.name}
     form
+    data-cy="tags-input"
 />
 
 <div>
     {#each value as tag (tag)}
-        <Button class="Button" type="button" data-tooltip="Click to remove" small on:click={handleRemove(tag)}>
+        <Button
+            class="Button"
+            type="button"
+            data-tooltip="Click to remove"
+            small
+            on:click={handleRemove(tag)}
+            data-cy="tags-value"
+        >
             {tag}
         </Button>
     {/each}

--- a/src/features/tags/settings/TagsSettings.spec.js
+++ b/src/features/tags/settings/TagsSettings.spec.js
@@ -1,0 +1,75 @@
+import { component as TagsSettings } from '.';
+import { tags } from '../store';
+
+describe('TagsSettings', () => {
+    beforeEach(() => {
+        cy.viewport(500, 500);
+
+        tags.set({});
+    });
+
+    it('renders empty state when there are no existing tags', () => {
+        cy.mount(TagsSettings);
+
+        cy.get('[data-cy="tags-empty"]').should('be.visible');
+    });
+
+    it('renders tags from the store', () => {
+        const data = {
+            one: { label: 'one' },
+            two: { label: 'two' },
+        };
+        tags.set(data);
+
+        cy.mount(TagsSettings);
+
+        for (const { label } of Object.values(data)) {
+            cy.contains(label);
+        }
+    });
+
+    it('includes "removed" class when the tag is marked for removal', () => {
+        const data = {
+            one: { label: 'one', removed: true },
+        };
+        tags.set(data);
+
+        cy.mount(TagsSettings);
+
+        cy.get('[data-cy="tag-item"]').should('have.class', 'removed');
+    });
+
+    it('marks the tag for removal when the action button is clicked for a tag that is not yet marked for removal', () => {
+        const data = {
+            one: { label: 'one' },
+        };
+        tags.set(data);
+
+        cy.mount(TagsSettings);
+
+        const tagsSpy = cy.spy();
+        tags.subscribe(tagsSpy);
+
+        cy.get('[data-cy="tag-action-btn"]').click();
+        cy.wrap(tagsSpy).should('have.been.calledWith', {
+            one: { label: 'one', removed: true },
+        });
+    });
+
+    it('unmarks the tag for removal when the action button is clicked for a tag that is already marked for removal', () => {
+        const data = {
+            one: { label: 'one', removed: true },
+        };
+        tags.set(data);
+
+        cy.mount(TagsSettings);
+
+        const tagsSpy = cy.spy();
+        tags.subscribe(tagsSpy);
+
+        cy.get('[data-cy="tag-action-btn"]').click();
+        cy.wrap(tagsSpy).should('have.been.calledWith', {
+            one: { label: 'one', removed: false },
+        });
+    });
+});

--- a/src/features/tags/settings/TagsSettings.svelte
+++ b/src/features/tags/settings/TagsSettings.svelte
@@ -22,7 +22,7 @@ const restoreTag = (tag) => {
 {#if hasTags}
     <ol>
         {#each sortedTags as tag (tag.label)}
-            <li class:removed={tag.removed}>
+            <li class:removed={tag.removed} data-cy="tag-item">
                 <Button
                     medium
                     icon
@@ -31,6 +31,7 @@ const restoreTag = (tag) => {
                     type="button"
                     class="Button"
                     on:click={() => (tag.removed ? restoreTag(tag) : removeTag(tag))}
+                    data-cy="tag-action-btn"
                 >
                     {tag.removed ? 'Restore' : 'Remove'}
                 </Button>
@@ -39,7 +40,7 @@ const restoreTag = (tag) => {
         {/each}
     </ol>
 {:else}
-    <p>No tags available. Tags added to todo items will appear in this tab.</p>
+    <p data-cy="tags-empty">No tags available. Tags added to todo items will appear in this tab.</p>
 {/if}
 
 <style>

--- a/src/features/tags/store.spec.js
+++ b/src/features/tags/store.spec.js
@@ -1,0 +1,92 @@
+import { STORAGE_KEY_TAGS } from '@lib/constants';
+import { todos } from '@features/todos/store';
+import { TODOS_TODAY } from '@features/todos/constants';
+import { tags } from './store';
+
+describe('tags store', () => {
+    beforeEach(() => {
+        tags.set({});
+    });
+
+    it('adds tag to store when tags.add is called', () => {
+        const tagsSpy = cy.spy();
+        tags.subscribe(tagsSpy);
+
+        tags.add(['one', 'two']);
+
+        cy.wrap(tagsSpy).should('have.been.calledWith', {
+            one: { label: 'one' },
+            two: { label: 'two' },
+        });
+    });
+
+    it('updates tag data when tags.updateTag is called', () => {
+        tags.set({
+            one: { label: 'one' },
+        });
+
+        const tagsSpy = cy.spy();
+        tags.subscribe(tagsSpy);
+
+        tags.updateTag('one', { removed: true });
+
+        cy.wrap(tagsSpy).should('have.been.calledWith', {
+            one: { label: 'one', removed: true },
+        });
+    });
+
+    it('saves only tags that are not removed and their allowed fields when tags.save is called', () => {
+        tags.set({
+            one: { label: 'one', unknown: 'field' },
+            two: { label: 'two', removed: true },
+        });
+
+        const tagsSpy = cy.spy();
+        tags.subscribe(tagsSpy);
+
+        tags.save();
+
+        cy.wrap(tagsSpy).should('have.been.calledWith', {
+            one: { label: 'one' },
+        });
+    });
+
+    it('updates todos to only include tags that are not removed when tags.save is called', () => {
+        const todo = {
+            id: 1,
+            body: 'todo',
+            list: TODOS_TODAY,
+            order: 1,
+            done: false,
+            tags: ['one', 'two'],
+        };
+        todos.set([todo]);
+
+        const todosSpy = cy.spy();
+        todos.subscribe(todosSpy);
+
+        tags.set({
+            one: { label: 'one' },
+            two: { label: 'two', removed: true },
+        });
+        tags.save();
+
+        cy.wrap(todosSpy).should('have.been.calledWith', [{ ...todo, tags: ['one'] }]);
+    });
+
+    it('saves data in localStorage when tags.saveInStorage is called', () => {
+        const data = {
+            one: { label: 'one' },
+        };
+        tags.saveInStorage(data);
+
+        cy.window().then((win) => {
+            cy.getAllLocalStorage().then((localStorage) => {
+                const storedTags = localStorage[win.location.origin][STORAGE_KEY_TAGS];
+                const expectedTags = JSON.stringify(data);
+
+                cy.wrap(storedTags).should('equal', expectedTags);
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Changes

- Add unit tests for the components and modules in src/features/shortcuts, partially implementing for #95

### Running the tests

```bash
npm test -- --spec src/features/tags
```

```text
       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  store.spec.js                            101ms        5        5        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  components/TagsInput.spec.js             570ms        4        4        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  settings/TagsSettings.spec.js            284ms        5        5        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        955ms       14       14        -        -        -
```