### PR TITLE
Add unit tests for themes feature components

### DIFF
--- a/src/features/themes/index.spec.js
+++ b/src/features/themes/index.spec.js
@@ -1,0 +1,23 @@
+import { settings } from '@features/settings/store';
+import { THEME_DARK, COLOR_PURPLE } from '@features/themes/constants';
+import { initializeThemes } from '.';
+
+describe('initializeThemes', () => {
+    beforeEach(() => {
+        cy.viewport(500, 500);
+    });
+
+    it('sets theme and color settings as data-attributes on the body element', () => {
+        initializeThemes();
+
+        settings.set({
+            theme: THEME_DARK,
+            color: COLOR_PURPLE,
+        });
+
+        cy.document().then((doc) => {
+            cy.wrap(doc.body).should('have.attr', 'data-theme', THEME_DARK);
+            cy.wrap(doc.body).should('have.attr', 'data-color', COLOR_PURPLE);
+        });
+    });
+});

--- a/src/features/themes/settings/ColorChoiceField.spec.js
+++ b/src/features/themes/settings/ColorChoiceField.spec.js
@@ -1,0 +1,31 @@
+import ColorChoiceField from './ColorChoiceField.svelte';
+import { COLOR_GREEN } from '../constants';
+
+const choice = {
+    value: COLOR_GREEN,
+};
+
+describe('ColorChoiceField', () => {
+    beforeEach(() => {
+        cy.viewport(120, 120);
+    });
+
+    it('does not add the selected class when selected prop is false', () => {
+        cy.mount(ColorChoiceField, {
+            props: { choice },
+        });
+
+        cy.get('p').should('not.have.class', 'selected');
+    });
+
+    it('adds the selected class when selected prop is true', () => {
+        cy.mount(ColorChoiceField, {
+            props: {
+                choice,
+                selected: true,
+            },
+        });
+
+        cy.get('p').should('have.class', 'selected');
+    });
+});

--- a/src/features/themes/settings/ThemeChoiceField.spec.js
+++ b/src/features/themes/settings/ThemeChoiceField.spec.js
@@ -1,0 +1,40 @@
+import ThemeChoiceField from './ThemeChoiceField.svelte';
+import { THEME_SYSTEM } from '../constants';
+
+const choice = {
+    label: 'System',
+    value: THEME_SYSTEM,
+};
+
+describe('ThemeChoiceField', () => {
+    beforeEach(() => {
+        cy.viewport(180, 180);
+    });
+
+    it('displays the choice label', () => {
+        cy.mount(ThemeChoiceField, {
+            props: { choice },
+        });
+
+        cy.get('p').should('contain.text', choice.label);
+    });
+
+    it('does not add the selected class when selected prop is false', () => {
+        cy.mount(ThemeChoiceField, {
+            props: { choice },
+        });
+
+        cy.get('p').should('not.have.class', 'selected');
+    });
+
+    it('adds the selected class when selected prop is true', () => {
+        cy.mount(ThemeChoiceField, {
+            props: {
+                choice,
+                selected: true,
+            },
+        });
+
+        cy.get('p').should('have.class', 'selected');
+    });
+});

--- a/src/features/themes/settings/ThemeSettings.spec.js
+++ b/src/features/themes/settings/ThemeSettings.spec.js
@@ -1,0 +1,64 @@
+import { component as ThemeSettings } from '.';
+import { COLOR_PURPLE, COLOR_YELLOW, THEME_DARK, THEME_SYSTEM } from '../constants';
+
+describe('ThemeSettings', () => {
+    beforeEach(() => {
+        cy.viewport(500, 500);
+    });
+
+    it('selects theme and color choices based on data prop', () => {
+        const data = {
+            theme: THEME_DARK,
+            color: COLOR_PURPLE,
+        };
+
+        cy.mount(ThemeSettings, {
+            props: { data },
+        });
+
+        cy.get(`[data-cy="theme-settings-selector"] input[value="${THEME_DARK}"]`).should('be.checked');
+        cy.get(`[data-cy="color-settings-selector"] input[value="${COLOR_PURPLE}"]`).should('be.checked');
+    });
+
+    it('dispatches "change" event when theme selection changes', () => {
+        const data = {
+            theme: THEME_DARK,
+            color: COLOR_PURPLE,
+        };
+        const changeSpy = cy.spy();
+
+        cy.mount(ThemeSettings, {
+            props: { data },
+        }).then(({ component }) => {
+            component.$on('change', changeSpy);
+        });
+        cy.get(`[data-cy="theme-settings-selector"] input[value="${THEME_SYSTEM}"]`).click({ force: true });
+
+        cy.wrap(changeSpy).should('have.been.called');
+        cy.wrap(data).should('deep.equal', {
+            theme: THEME_SYSTEM,
+            color: COLOR_PURPLE,
+        });
+    });
+
+    it('dispatches "change" event when color selection changes', () => {
+        const data = {
+            theme: THEME_DARK,
+            color: COLOR_PURPLE,
+        };
+        const changeSpy = cy.spy();
+
+        cy.mount(ThemeSettings, {
+            props: { data },
+        }).then(({ component }) => {
+            component.$on('change', changeSpy);
+        });
+        cy.get(`[data-cy="color-settings-selector"] input[value="${COLOR_YELLOW}"]`).click({ force: true });
+
+        cy.wrap(changeSpy).should('have.been.called');
+        cy.wrap(data).should('deep.equal', {
+            theme: THEME_DARK,
+            color: COLOR_YELLOW,
+        });
+    });
+});


### PR DESCRIPTION
### Changes

- Add unit tests for the components and modules in `src/features/themes`, partially implementing for #95

### Running the tests

```bash
npm test -- --spec src/features/themes
```

```text
       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  index.spec.js                             53ms        1        1        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  settings/ColorChoiceField.spec.js         54ms        2        2        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  settings/ThemeChoiceField.spec.js         71ms        3        3        -        -        - │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  settings/ThemeSettings.spec.js           208ms        3        3        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        386ms        9        9        -        -        -
```