### PR TITLE
Support links in todo bodies

### DIFF
--- a/src/features/todos/components/TodoForm.spec.js
+++ b/src/features/todos/components/TodoForm.spec.js
@@ -22,9 +22,9 @@ describe('TodoForm', () => {
         cy.get(`[data-cy="todo-form-list"] input[value="${data.list}"]`).should('be.checked');
     });
 
-    it('unsanitizes todo body from data prop when displaying it in the form', () => {
+    it('escapes and unsanitizes todo body from data prop when displaying it in the form', () => {
         const data = {
-            body: '&lt;test todo&gt;',
+            body: '<strong>test todo</strong>',
             list: TODOS_THIS_WEEK,
         };
 
@@ -32,7 +32,7 @@ describe('TodoForm', () => {
             props: { data },
         });
 
-        cy.get('[data-cy="todo-form-body"]').should('have.text', '<test todo>');
+        cy.get('[data-cy="todo-form-body"]').should('have.text', '<strong>test todo</strong>');
     });
 
     it('disables submit button when todo body is not specified', () => {

--- a/src/features/todos/components/TodoForm.svelte
+++ b/src/features/todos/components/TodoForm.svelte
@@ -7,14 +7,14 @@ import TodoFormOptionalFields from './TodoFormOptionalFields.svelte';
 
 import { disableShortcut, enableShortcut } from '@features/shortcuts';
 import { TODOS_EVENTUALLY, TODOS_THIS_WEEK, TODOS_TODAY } from '../constants';
-import { sanitizeText, unsanitizeText } from '../lib/sanitize';
+import { escapeText, sanitizeText, unsanitizeText } from '../lib/sanitize';
 
 export let data = {
     list: TODOS_EVENTUALLY,
 };
 
 if (data.body) {
-    data.body = unsanitizeText(data.body);
+    data.body = unsanitizeText(escapeText(data.body));
 }
 
 const listChoices = [
@@ -31,7 +31,7 @@ const handlePaste = async () => {
     // We need this to make sure that the DOM has updated with new content before
     // we try to sanitize its content.
     setTimeout(() => {
-        data.body = unsanitizeText(sanitizeText(data.body));
+        data.body = unsanitizeText(sanitizeText(escapeText(data.body)));
     }, 0);
 };
 

--- a/src/features/todos/components/TodoItem.spec.js
+++ b/src/features/todos/components/TodoItem.spec.js
@@ -35,6 +35,20 @@ describe('TodoItem', () => {
         }
     });
 
+    it('turns urls in todo body into links', () => {
+        const todo = generateTodo({
+            body: 'this todo contains a link https://simple-todo.arnelle.dev',
+        });
+        settings.set({ todoDateDisplay: TODOS_DATE_ABSOLUTE });
+
+        cy.mount(TodoItem, {
+            props: { todo },
+        });
+
+        cy.get('a').should('have.attr', 'href', 'https://simple-todo.arnelle.dev');
+        cy.get('a').should('have.text', 'https://simple-todo.arnelle.dev');
+    });
+
     it('includes the "done" class and checks the checkbox when todo is marked as done', () => {
         const todo = generateTodo({ done: true });
 

--- a/src/features/todos/components/TodoItem.svelte
+++ b/src/features/todos/components/TodoItem.svelte
@@ -8,13 +8,14 @@ import TodoItemMenu from './TodoItemMenu.svelte';
 import TodoItemTags from './TodoItemTags.svelte';
 
 import { settings } from '@features/settings/store';
+import { linkify } from '../lib/linkify';
 import { escapeText } from '../lib/sanitize';
 
 export let todo;
 $: hasTags = (todo.tags?.length ?? 0) > 0;
 $: hasDate = Boolean(todo.date);
 $: hasBadges = hasTags || hasDate;
-$: todoBody = escapeText(todo.body);
+$: todoBody = linkify(escapeText(todo.body));
 
 const dispatch = createEventDispatcher();
 const toggleTodoDone = (event) => dispatch('update', { id: todo.id, done: event.detail });

--- a/src/features/todos/components/TodoItem.svelte
+++ b/src/features/todos/components/TodoItem.svelte
@@ -8,11 +8,13 @@ import TodoItemMenu from './TodoItemMenu.svelte';
 import TodoItemTags from './TodoItemTags.svelte';
 
 import { settings } from '@features/settings/store';
+import { escapeText } from '../lib/sanitize';
 
 export let todo;
 $: hasTags = (todo.tags?.length ?? 0) > 0;
 $: hasDate = Boolean(todo.date);
 $: hasBadges = hasTags || hasDate;
+$: todoBody = escapeText(todo.body);
 
 const dispatch = createEventDispatcher();
 const toggleTodoDone = (event) => dispatch('update', { id: todo.id, done: event.detail });
@@ -27,7 +29,7 @@ const toggleTodoDone = (event) => dispatch('update', { id: todo.id, done: event.
 >
     <Checkbox checked={todo.done} on:change={toggleTodoDone} data-cy="todo-item-done" />
     <div class="TodoDetails" data-cy="todo-item-details">
-        <p><span>{todo.body}</span></p>
+        <p><span>{@html todoBody}</span></p>
 
         {#if hasBadges}
             <ol class="TodoBadges">

--- a/src/features/todos/lib/linkify.js
+++ b/src/features/todos/lib/linkify.js
@@ -1,0 +1,5 @@
+const linkPattern = /(https?:\/\/[^\s]+)/g;
+
+export function linkify(text) {
+    return text.replace(linkPattern, '<a href="$1">$1</a>');
+}

--- a/src/features/todos/lib/linkify.spec.js
+++ b/src/features/todos/lib/linkify.spec.js
@@ -1,0 +1,11 @@
+import { linkify } from './linkify';
+
+describe('linkify', () => {
+    it('converts urls in text into links', () => {
+        const input = 'hello https://simple-todo.arnelle.dev world';
+        const expected = 'hello <a href="https://simple-todo.arnelle.dev">https://simple-todo.arnelle.dev</a> world';
+        const result = linkify(input);
+
+        expect(result).to.equal(expected);
+    });
+});

--- a/src/features/todos/lib/sanitize.js
+++ b/src/features/todos/lib/sanitize.js
@@ -10,9 +10,6 @@ const escapedCharacters = [
 
 export function sanitizeText(text) {
     div.innerHTML = text
-        // Handle special case when user adds "<>" to the body, saves, edits, then saves again
-        .replace(/<>/g, '&lt;&gt;')
-
         // Make each <div>'s content into a separate line
         .replace(/<div.*?>(.+?)<\/div>/g, '\n$1')
 

--- a/src/features/todos/lib/sanitize.js
+++ b/src/features/todos/lib/sanitize.js
@@ -1,5 +1,13 @@
 const div = document.createElement('div');
 
+const escapedCharacters = [
+    ['&', '&amp;'],
+    ['<', '&lt;'],
+    ['>', '&gt;'],
+    ['"', '&quot;'],
+    ["'", '&#39;'],
+];
+
 export function sanitizeText(text) {
     div.innerHTML = text
         // Handle special case when user adds "<>" to the body, saves, edits, then saves again
@@ -20,11 +28,24 @@ export function unsanitizeText(text) {
         text
             // Wrap each line in a <div>
             .replace(/\n(.+)/g, (match, content) => {
-                div.textContent = content;
-                return `<div>${div.innerHTML}</div>`;
+                return `<div>${content}</div>`;
             })
 
             // Convert remaining newlines into <br>
             .replace(/\n/g, '<div><br></div>')
     );
+}
+
+export function escapeText(text) {
+    for (const [character, escaped] of escapedCharacters) {
+        text = text.replace(new RegExp(character, 'g'), escaped);
+    }
+    return text;
+}
+
+export function unescapeText(text) {
+    for (const [character, escaped] of escapedCharacters) {
+        text = text.replace(new RegExp(escaped, 'g'), character);
+    }
+    return text;
 }

--- a/src/features/todos/lib/sanitize.spec.js
+++ b/src/features/todos/lib/sanitize.spec.js
@@ -1,0 +1,57 @@
+import { escapeText, sanitizeText, unescapeText, unsanitizeText } from './sanitize';
+
+describe('sanitizeText', () => {
+    it('turns div contents into multiple lines', () => {
+        const input = '<div>hello</div><div>world</div>';
+        const expected = 'hello\nworld';
+        const result = sanitizeText(input);
+
+        expect(result).to.equal(expected);
+    });
+
+    it('removes tags and non-breaking spaces', () => {
+        const input = '<strong>hello&nbsp;world</strong>';
+        const expected = 'helloworld';
+        const result = sanitizeText(input);
+
+        expect(result).to.equal(expected);
+    });
+});
+
+describe('unsanitizeText', () => {
+    it('wraps lines inside div elements', () => {
+        const input = 'hello\nworld';
+        const expected = 'hello<div>world</div>';
+        const result = unsanitizeText(input);
+
+        expect(result).to.equal(expected);
+    });
+
+    it('turns extra newlines into <br> elements', () => {
+        const input = 'hello\n\nworld';
+        const expected = 'hello<div><br></div><div>world</div>';
+        const result = unsanitizeText(input);
+
+        expect(result).to.equal(expected);
+    });
+});
+
+describe('escapeText', () => {
+    it('converts actual characters into escaped characters', () => {
+        const input = '&<>"\'';
+        const expected = '&amp;&lt;&gt;&quot;&#39;';
+        const result = escapeText(input);
+
+        expect(result).to.equal(expected);
+    });
+});
+
+describe('unescapeText', () => {
+    it('converts escaped characters into actual characters', () => {
+        const input = '&amp;&lt;&gt;&quot;&#39;';
+        const expected = '&<>"\'';
+        const result = unescapeText(input);
+
+        expect(result).to.equal(expected);
+    });
+});


### PR DESCRIPTION
Resolves #36 

### Changes

- Turns urls in todo bodies into clickable links

### Preview

<img width="420" alt="image" src="https://github.com/user-attachments/assets/0d07798d-1a24-46b4-9819-c700c9b88a1e">
